### PR TITLE
Get policy service principals

### DIFF
--- a/altimeter/aws/resource/iam/role.py
+++ b/altimeter/aws/resource/iam/role.py
@@ -55,6 +55,9 @@ class IAMRoleResourceSpec(IAMResourceSpec):
                         ListField(
                             "Federated", EmbeddedScalarField(), optional=True, allow_scalar=True
                         ),
+                        ListField(
+                            "Service", EmbeddedScalarField(), optional=True, allow_scalar=True
+                        ),
                     ),
                 ),
             ),


### PR DESCRIPTION
This PR modifies the AssumeRolePolicyDocument of a role so it also takes into account the "Service" principals.

