### PR TITLE
Pin MarkupSafe version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,7 @@ jinja2>=2.11.1,<3
 pydantic>=1.6.1,<2
 toml>=0.10.0,<1
 gremlinpython>=3.4.7,<3.5
+
+# Pin version of MarkupSafe to avoid this error:
+# https://github.com/aws/aws-sam-cli/pull/3662
+MarkupSafe==2.0.1

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setup(
         "structlog>=20.1.0,<21",
         "boto3>=1.17.41,<2",
         "jinja2>=2.11.1,<3",
+        "MarkupSafe==2.0.1",
         "pydantic>=1.6.1,<2",
         "toml>=0.10.0,<1",
         "gremlinpython>=3.4.7,<3.5",

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -7,3 +7,7 @@ docker==4.4.4
 aws-sam-translator==1.29.0
 pytest>=6.2.0,<7
 pytest-cov>=2.10.1,<3
+
+# Pin version of MarkupSafe to avoid this error:
+# https://github.com/aws/aws-sam-cli/pull/3662
+MarkupSafe==2.0.1


### PR DESCRIPTION
Pin the version of the MarkupSafe dependency to avoid using an incompatible version of the library.