### PR TITLE
Get embedded and attached policies for users and groups

### DIFF
--- a/altimeter/aws/resource/iam/group.py
+++ b/altimeter/aws/resource/iam/group.py
@@ -47,10 +47,7 @@ class IAMGroupResourceSpec(IAMResourceSpec):
         ),
         ListField(
             "EmbeddedPolicy",
-            EmbeddedDictField(
-                ScalarField("PolicyName"),
-                ScalarField("PolicyDocument"),
-            ),
+            EmbeddedDictField(ScalarField("PolicyName"), ScalarField("PolicyDocument"),),
             optional=True,
         ),
     )

--- a/altimeter/aws/resource/iam/group.py
+++ b/altimeter/aws/resource/iam/group.py
@@ -6,11 +6,16 @@ from botocore.exceptions import ClientError
 
 from altimeter.aws.resource.resource_spec import ListFromAWSResult
 from altimeter.aws.resource.iam import IAMResourceSpec
+from altimeter.aws.resource.iam.policy import IAMPolicyResourceSpec
+from altimeter.aws.resource.util import policy_doc_dict_to_sorted_str
 from altimeter.aws.resource.iam.user import IAMUserResourceSpec
-from altimeter.core.graph.field.dict_field import AnonymousEmbeddedDictField
-from altimeter.core.graph.field.list_field import AnonymousListField
+from altimeter.core.graph.field.list_field import AnonymousListField, ListField
 from altimeter.core.graph.field.resource_link_field import ResourceLinkField
 from altimeter.core.graph.field.scalar_field import ScalarField
+from altimeter.core.graph.field.dict_field import (
+    EmbeddedDictField,
+    AnonymousEmbeddedDictField,
+)
 from altimeter.core.graph.schema import Schema
 
 
@@ -28,6 +33,23 @@ class IAMGroupResourceSpec(IAMResourceSpec):
                 ResourceLinkField("Arn", IAMUserResourceSpec, value_is_id=True, alti_key="user")
             ),
         ),
+        AnonymousListField(
+            "PolicyAttachments",
+            AnonymousEmbeddedDictField(
+                ResourceLinkField(
+                    "PolicyArn",
+                    IAMPolicyResourceSpec,
+                    optional=True,
+                    value_is_id=True,
+                    alti_key="attached_policy",
+                )
+            ),
+        ),
+        ListField(
+            "EmbeddedPolicy",
+            EmbeddedDictField(ScalarField("PolicyName"), ScalarField("PolicyDocument"),),
+            optional=True,
+            ),
     )
 
     @classmethod
@@ -46,11 +68,16 @@ class IAMGroupResourceSpec(IAMResourceSpec):
         for resp in paginator.paginate():
             for group in resp.get("Groups", []):
                 resource_arn = group["Arn"]
+                group_name = group["GroupName"]
                 try:
                     group["Users"] = cls.get_group_users(
-                        client=client, group_name=group["GroupName"]
+                        client=client, group_name=group_name
                     )
                     groups[resource_arn] = group
+                    attached_policies = get_attached_group_policies(client, group_name)
+                    group["PolicyAttachments"] = attached_policies
+                    embedded_policies = get_embedded_group_policies(client, group_name)
+                    group["EmbeddedPolicy"] = embedded_policies
                 except ClientError as c_e:
                     error_code = getattr(c_e, "response", {}).get("Error", {}).get("Code", {})
                     if error_code != "NoSuchEntity":
@@ -63,3 +90,38 @@ class IAMGroupResourceSpec(IAMResourceSpec):
     ) -> List[Dict[str, Any]]:
         group_resp = client.get_group(GroupName=group_name)
         return group_resp["Users"]
+
+
+def get_attached_group_policies(client: BaseClient, group_name: str) -> List[Dict[str, Any]]:
+    """Get attached group policies"""
+    policies = []
+    paginator = client.get_paginator("list_attached_group_policies")
+    for resp in paginator.paginate(GroupName=group_name):
+        for policy in resp.get("AttachedPolicies", []):
+            policies.append(policy)
+    return policies
+
+
+def get_embedded_group_policies(client: BaseClient, group_name: str) -> List[Dict[str, Any]]:
+    """Get embedded group policies"""
+    policies = []
+    paginator = client.get_paginator("list_group_policies")
+    for resp in paginator.paginate(GroupName=group_name):
+        for policy_name in resp.get("PolicyNames", []):
+            policy = get_embedded_group_policy(client, group_name, policy_name)
+            policies.append(policy)
+    return policies
+
+
+def get_embedded_group_policy(
+    client: BaseClient, group_name: str, policy_name: str
+) -> Dict[str, str]:
+    """Get embedded group policy"""
+    resp = client.get_group_policy(GroupName=group_name, PolicyName=policy_name)
+    policy_document = resp.get("PolicyDocument")
+    policy_name = resp.get("PolicyName")
+    policy_document = policy_doc_dict_to_sorted_str(policy_document)
+    return {
+        "PolicyName": policy_name,
+        "PolicyDocument": policy_document,
+    }

--- a/altimeter/aws/resource/iam/group.py
+++ b/altimeter/aws/resource/iam/group.py
@@ -47,9 +47,12 @@ class IAMGroupResourceSpec(IAMResourceSpec):
         ),
         ListField(
             "EmbeddedPolicy",
-            EmbeddedDictField(ScalarField("PolicyName"), ScalarField("PolicyDocument"),),
-            optional=True,
+            EmbeddedDictField(
+                ScalarField("PolicyName"),
+                ScalarField("PolicyDocument"),
             ),
+            optional=True,
+        ),
     )
 
     @classmethod
@@ -70,9 +73,7 @@ class IAMGroupResourceSpec(IAMResourceSpec):
                 resource_arn = group["Arn"]
                 group_name = group["GroupName"]
                 try:
-                    group["Users"] = cls.get_group_users(
-                        client=client, group_name=group_name
-                    )
+                    group["Users"] = cls.get_group_users(client=client, group_name=group_name)
                     groups[resource_arn] = group
                     attached_policies = get_attached_group_policies(client, group_name)
                     group["PolicyAttachments"] = attached_policies

--- a/altimeter/aws/resource/iam/user.py
+++ b/altimeter/aws/resource/iam/user.py
@@ -13,7 +13,7 @@ from altimeter.core.graph.field.dict_field import (
     AnonymousDictField,
     DictField,
     EmbeddedDictField,
-    AnonymousEmbeddedDictField
+    AnonymousEmbeddedDictField,
 )
 from altimeter.core.graph.field.list_field import AnonymousListField, ListField
 from altimeter.core.graph.field.resource_link_field import ResourceLinkField
@@ -61,14 +61,17 @@ class IAMUserResourceSpec(IAMResourceSpec):
                     optional=True,
                     value_is_id=True,
                     alti_key="attached_policy",
-            )
-        ),
-    ),
-        ListField(
-                "EmbeddedPolicy",
-                EmbeddedDictField(ScalarField("PolicyName"), ScalarField("PolicyDocument"),),
-                optional=True,
+                )
             ),
+        ),
+        ListField(
+            "EmbeddedPolicy",
+            EmbeddedDictField(
+                ScalarField("PolicyName"),
+                ScalarField("PolicyDocument"),
+            ),
+            optional=True,
+        ),
     )
 
     @classmethod
@@ -179,9 +182,8 @@ def get_embedded_user_policies(client: BaseClient, username: str) -> List[Dict[s
             policies.append(policy)
     return policies
 
-def get_embedded_user_policy(
-    client: BaseClient, username: str, policy_name: str
-) -> Dict[str, str]:
+
+def get_embedded_user_policy(client: BaseClient, username: str, policy_name: str) -> Dict[str, str]:
     """Get embedded user policy"""
     resp = client.get_user_policy(UserName=username, PolicyName=policy_name)
     policy_document = resp.get("PolicyDocument")

--- a/altimeter/aws/resource/iam/user.py
+++ b/altimeter/aws/resource/iam/user.py
@@ -66,10 +66,7 @@ class IAMUserResourceSpec(IAMResourceSpec):
         ),
         ListField(
             "EmbeddedPolicy",
-            EmbeddedDictField(
-                ScalarField("PolicyName"),
-                ScalarField("PolicyDocument"),
-            ),
+            EmbeddedDictField(ScalarField("PolicyName"), ScalarField("PolicyDocument"),),
             optional=True,
         ),
     )

--- a/altimeter/aws/resource/iam/user.py
+++ b/altimeter/aws/resource/iam/user.py
@@ -4,11 +4,19 @@ from typing import Any, Dict, List, Optional, Type
 
 from botocore.client import BaseClient
 from botocore.exceptions import ClientError
+from altimeter.aws.resource.iam.policy import IAMPolicyResourceSpec
 
+from altimeter.aws.resource.util import policy_doc_dict_to_sorted_str
 from altimeter.aws.resource.resource_spec import ListFromAWSResult
 from altimeter.aws.resource.iam import IAMResourceSpec
-from altimeter.core.graph.field.dict_field import AnonymousDictField, DictField, EmbeddedDictField
-from altimeter.core.graph.field.list_field import ListField
+from altimeter.core.graph.field.dict_field import (
+    AnonymousDictField,
+    DictField,
+    EmbeddedDictField,
+    AnonymousEmbeddedDictField
+)
+from altimeter.core.graph.field.list_field import AnonymousListField, ListField
+from altimeter.core.graph.field.resource_link_field import ResourceLinkField
 from altimeter.core.graph.field.scalar_field import ScalarField
 from altimeter.core.graph.schema import Schema
 
@@ -44,6 +52,23 @@ class IAMUserResourceSpec(IAMResourceSpec):
             EmbeddedDictField(ScalarField("SerialNumber"), ScalarField("EnableDate")),
             optional=True,
         ),
+        AnonymousListField(
+            "PolicyAttachments",
+            AnonymousEmbeddedDictField(
+                ResourceLinkField(
+                    "PolicyArn",
+                    IAMPolicyResourceSpec,
+                    optional=True,
+                    value_is_id=True,
+                    alti_key="attached_policy",
+            )
+        ),
+    ),
+        ListField(
+                "EmbeddedPolicy",
+                EmbeddedDictField(ScalarField("PolicyName"), ScalarField("PolicyDocument"),),
+                optional=True,
+            ),
     )
 
     @classmethod
@@ -71,6 +96,10 @@ class IAMUserResourceSpec(IAMResourceSpec):
                     if login_profile is not None:
                         user["LoginProfile"] = login_profile
                     users[resource_arn] = user
+                    attached_policies = get_attached_user_policies(client, username)
+                    user["PolicyAttachments"] = attached_policies
+                    embedded_policies = get_embedded_user_policies(client, username)
+                    user["EmbeddedPolicy"] = embedded_policies
                 except ClientError as c_e:
                     error_code = getattr(c_e, "response", {}).get("Error", {}).get("Code", {})
                     if error_code != "NoSuchEntity":
@@ -128,3 +157,37 @@ class IAMUserResourceSpec(IAMResourceSpec):
             if error_code != "NoSuchEntity":
                 raise c_e
         return None
+
+
+def get_attached_user_policies(client: BaseClient, username: str) -> List[Dict[str, Any]]:
+    """Get attached user policies"""
+    policies = []
+    paginator = client.get_paginator("list_attached_user_policies")
+    for resp in paginator.paginate(UserName=username):
+        for policy in resp.get("AttachedPolicies", []):
+            policies.append(policy)
+    return policies
+
+
+def get_embedded_user_policies(client: BaseClient, username: str) -> List[Dict[str, Any]]:
+    """Get embedded user policies"""
+    policies = []
+    paginator = client.get_paginator("list_user_policies")
+    for resp in paginator.paginate(UserName=username):
+        for policy_name in resp.get("PolicyNames", []):
+            policy = get_embedded_user_policy(client, username, policy_name)
+            policies.append(policy)
+    return policies
+
+def get_embedded_user_policy(
+    client: BaseClient, username: str, policy_name: str
+) -> Dict[str, str]:
+    """Get embedded user policy"""
+    resp = client.get_user_policy(UserName=username, PolicyName=policy_name)
+    policy_document = resp.get("PolicyDocument")
+    policy_name = resp.get("PolicyName")
+    policy_document = policy_doc_dict_to_sorted_str(policy_document)
+    return {
+        "PolicyName": policy_name,
+        "PolicyDocument": policy_document,
+    }


### PR DESCRIPTION
This PR modifies the Altimeter, so now, it gathers the embedded and attached policies for both users and groups.