### PR TITLE
Add an account id property to lpg vertices

### DIFF
--- a/altimeter/aws/resource/resource_spec.py
+++ b/altimeter/aws/resource/resource_spec.py
@@ -154,7 +154,9 @@ class AWSResourceSpec(ResourceSpec):
         context = {"account_id": scan_accessor.account_id, "region": scan_accessor.region}
         list_from_aws_result = cls._list_from_aws(scan_accessor)
         resources = cls._list_from_aws_result_to_resources(
-            list_from_aws_result=list_from_aws_result, context=context
+            list_from_aws_result=list_from_aws_result,
+            context=context,
+            account_id= scan_accessor.account_id,
         )
         return resources
 
@@ -185,6 +187,7 @@ class AWSResourceSpec(ResourceSpec):
         cls: Type["AWSResourceSpec"],
         list_from_aws_result: ListFromAWSResult,
         context: Dict[str, str],
+        account_id: str,
     ) -> List[Resource]:
         resources: List[Resource] = []
         for arn, resource_dict in list_from_aws_result.resources.items():
@@ -217,7 +220,10 @@ class AWSResourceSpec(ResourceSpec):
             )
 
             resource = Resource(
-                resource_id=arn, type=cls.get_full_type_name(), link_collection=link_collection,
+                resource_id=arn,
+                type=cls.get_full_type_name(),
+                link_collection=link_collection,
+                account_id= account_id,
             )
             resources.append(resource)
         return resources

--- a/altimeter/aws/resource/unscanned_account.py
+++ b/altimeter/aws/resource/unscanned_account.py
@@ -32,6 +32,7 @@ class UnscannedAccountResourceSpec(AWSResourceSpec):
             resource_id=cls.generate_arn(resource_id=account_id),
             type=cls.get_full_type_name(),
             link_collection=LinkCollection(simple_links=simple_links),
+            account_id= account_id,
         )
 
     @classmethod

--- a/altimeter/core/graph/links.py
+++ b/altimeter/core/graph/links.py
@@ -137,6 +137,7 @@ class MultiLink(BaseLink):
         v = {
             "~id": vertex_id,
             "~label": self.pred,
+            "account_id": parent["account_id"],
         }
         edge_label = prefix if prefix != "" else self.pred
         edge = {
@@ -276,6 +277,7 @@ class TagLink(BaseLink):
             vertex["~id"] = f"{self.pred}:{self.obj}"
             vertex["~label"] = "tag"
             vertex[self.pred] = self.obj
+            vertex["account_id"] = parent["account_id"]
             vertices.append(vertex)
         edge = {
             "~id": uuid.uuid1(),

--- a/altimeter/core/resource/resource.py
+++ b/altimeter/core/resource/resource.py
@@ -20,6 +20,7 @@ class Resource(BaseImmutableModel):
     resource_id: str
     type: str
     link_collection: LinkCollection
+    account_id: str
 
     def to_rdf(self, namespace: Namespace, graph: Graph, node_cache: NodeCache) -> None:
         """Graph this Resource as a URIRef on a Graph.
@@ -48,6 +49,7 @@ class Resource(BaseImmutableModel):
             "~id": self.resource_id,
             "~label": self.type,
             "arn": self.resource_id,
+            "account_id": self.account_id,
         }
         self.link_collection.to_lpg(vertex, vertices, edges)
         vertices.append(vertex)

--- a/altimeter/core/resource/resource_spec.py
+++ b/altimeter/core/resource/resource_spec.py
@@ -192,6 +192,8 @@ class ResourceSpec(abc.ABC):
             resources = spec_classes_resources[winning_class]
         full_type_names = {resource.type for resource in resources}
         merged_resource_type_name = full_type_names.pop()
+        account_ids = [resource.account_id for resource in resources]
+        merged_account_id = account_ids.pop()
         merged_link_keys_links: Dict[str, Link] = {}
         for duplicate_resource in resources:
             for link in duplicate_resource.link_collection.get_links():
@@ -214,6 +216,7 @@ class ResourceSpec(abc.ABC):
             resource_id=resource_id,
             type=merged_resource_type_name,
             link_collection=link_collection,
+            account_id= merged_account_id,
         )
 
 


### PR DESCRIPTION
This PR adds the property "account_id" to all the vertices generated by an Altimeter scan when written to an lpg graph.
 