### PR TITLE
Use transient resource links for EC2 instance SGs

### DIFF
--- a/altimeter/aws/resource/ec2/instance.py
+++ b/altimeter/aws/resource/ec2/instance.py
@@ -44,7 +44,9 @@ class EC2InstanceResourceSpec(EC2ResourceSpec):
         ResourceLinkField("SubnetId", SubnetResourceSpec, optional=True),
         AnonymousListField(
             "SecurityGroups",
-            AnonymousEmbeddedDictField(TransientResourceLinkField("GroupId", SecurityGroupResourceSpec)),
+            AnonymousEmbeddedDictField(
+                TransientResourceLinkField("GroupId", SecurityGroupResourceSpec)
+            ),
         ),
         AnonymousDictField(
             "IamInstanceProfile",


### PR DESCRIPTION
We have seen AWS accounts with stopped EC2 instances that had nonexistent security groups attached. This kind of scenario makes Altimeter fail with a `GraphSetOrphanedReferencesException` exception.

This PR changes EC2 instance SGs resource links to transient resource links.