### PR TITLE
Make the Field UserId in the UserIdGroupPairs for a Security Group optional

### DIFF
--- a/altimeter/aws/resource/ec2/security_group.py
+++ b/altimeter/aws/resource/ec2/security_group.py
@@ -88,7 +88,7 @@ class SecurityGroupResourceSpec(EC2ResourceSpec):
                     "UserIdGroupPairs",
                     EmbeddedDictField(
                         ResourceLinkField("GroupId", "SecurityGroupResourceSpec"),
-                        ScalarField("UserId", alti_key="account_id"),
+                        ScalarField("UserId", alti_key="account_id", optional=True),
                         ScalarField("PeeringStatus", optional=True),
                         ScalarField("VpcId", optional=True),
                         ScalarField("VpcPeeringConnectionId", optional=True),


### PR DESCRIPTION
This PR modifies the specification of the ``SecurityGroupResourceSpec`` class, so now the field "UserId" of the items in the embedded dictionary field "UserIdGroupPairs" is not mandatory. The reason to make that field optional is that there are some cases, like for instance when the pair is referring to a VPC peering connection that was deleted, in which this field is not specified for the pair. 